### PR TITLE
Handled case where reader() would panic on packet of incorrect protocol.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -370,6 +370,15 @@ func (l *LDAPConnection) reader() {
 
 		addLDAPDescriptions(p)
 
+		if len(p.Children) < 1 {
+			errorMessage := "ldap.reader: Incorrect protocol detected."
+			if strData := p.Data.String(); strData != "<nil>" {
+				errorMessage += " Packet data: " + strData
+			}
+			log.Errorln(errorMessage)
+			return
+		}
+
 		message_id := p.Children[0].Value.(uint64)
 		message_packet := &messagePacket{Op: MessageResponse, MessageID: message_id, Packet: p}
 


### PR DESCRIPTION
Fixes https://github.com/demisto/etc/issues/16444

**Description:**
`reader()` would panic on packet of incorrect protocol (because `Children` would be empty).
Changed the implementation so it will handle the error gracefully and log a useful error message.